### PR TITLE
Support building with go14

### DIFF
--- a/astcontext/funcs.go
+++ b/astcontext/funcs.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
-	"go/types"
 	"sort"
 )
 
@@ -83,7 +82,7 @@ func NewFuncSignature(node ast.Node) *FuncSignature {
 			}
 
 			buf := new(bytes.Buffer)
-			types.WriteExpr(buf, p.Type)
+			writeExpr(buf, p.Type)
 			out += buf.String()
 
 			if len(list) != i+1 {

--- a/astcontext/types.go
+++ b/astcontext/types.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/ast"
-	"go/types"
 )
 
 // TypeSignature represents a type declaration signature
@@ -40,7 +39,7 @@ type Types []*Type
 // NewTypeSignature returns a TypeSignature from the given typespec node
 func NewTypeSignature(node *ast.TypeSpec) *TypeSignature {
 	buf := new(bytes.Buffer)
-	types.WriteExpr(buf, node.Type)
+	writeExpr(buf, node.Type)
 
 	sig := &TypeSignature{
 		Name: node.Name.Name,

--- a/astcontext/types_go14.go
+++ b/astcontext/types_go14.go
@@ -1,0 +1,14 @@
+// +build go1.4,!go1.5
+
+package astcontext
+
+import (
+	"bytes"
+	"go/ast"
+
+	"golang.org/x/tools/go/types"
+)
+
+func writeExpr(buf *bytes.Buffer, x ast.Expr) {
+	types.WriteExpr(buf, x)
+}

--- a/astcontext/types_go15.go
+++ b/astcontext/types_go15.go
@@ -1,0 +1,13 @@
+// +build go1.5
+
+package astcontext
+
+import (
+	"bytes"
+	"go/ast"
+	"go/types"
+)
+
+func writeExpr(buf *bytes.Buffer, x ast.Expr) {
+	types.WriteExpr(buf, x)
+}


### PR DESCRIPTION
Add support for building with go14 by creating a wrapper for WriteExpr which uses golang.org/x/tools/go/types under go v1.4 and go/types on go v1.5+.