### PR TITLE
Add "comment" mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
-go: 
- - 1.6
+go:
+ - 1.10.x
  - tip

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Motion is a tool that was designed to work with editors. It is providing
 contextual information for a given offset(option) from a file or directory of
 files.  Editors can use these informations to implement navigation, text
-editing, etc... that are specific to a Go source code. 
+editing, etc... that are specific to a Go source code.
 
 It's optimized and created to work with
 [vim-go](https://github.com/fatih/vim-go), but it's designed to work with any
@@ -25,6 +25,7 @@ modes you can use:
   offset
 * `next`: returns the next function information for a given offset
 * `prev`: returns the previous function information for a given offset
+* `comment`: returns information about the a comment block (if any).
 
 A `function information` is currently the following type definition (defined as
 `astcontext.Func`):
@@ -46,7 +47,7 @@ type Func struct {
 }
 ```
 
-`motion` can output the information currently in formats: `json` and `vim`. 
+`motion` can output the information currently in formats: `json` and `vim`.
 
 An example execution for the `enclosing` mode and output in `json` format is:
 
@@ -174,7 +175,7 @@ $ motion -file testdata/main.go -offset 330 -mode next --format json
 }
 ```
 
-Lastly for the mode `decls`, we pass the file (you can also pass a directory)
+For the mode `decls`, we pass the file (you can also pass a directory)
 and instruct to only include function declarations with the `-include func`
 flag:
 ```
@@ -207,5 +208,20 @@ $ motion -file testdata/main.go -mode decls -include func
 			"col": 1
 		}
 	]
+}
+```
+
+In the `comment` mode it will try to get information about the comment block for
+a given offset:
+```
+$ motion -mode comment -file ./vim/vim.go -offset 3
+{
+        "mode": "comment",
+        "comment": {
+                "startLine": 1,
+                "startCol": 1,
+                "endLine": 3,
+                "endCol": 50
+        }
 }
 ```

--- a/astcontext/query_test.go
+++ b/astcontext/query_test.go
@@ -1,0 +1,70 @@
+package astcontext
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestComment(t *testing.T) {
+	var src = `package main
+
+// Hello
+
+/* foo
+bar */
+
+// ..
+// ..
+`
+	opts := &ParserOptions{Src: []byte(src), Comments: true}
+	parser, err := NewParser(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		offset  int
+		want    Comment
+		wantErr string
+	}{
+		{4, Comment{}, "no comment block"},
+		{9000, Comment{}, "no comment block"},
+		{18, Comment{3, 1, 3, 9}, ""},
+		{24, Comment{5, 1, 6, 7}, ""},
+		{39, Comment{8, 1, 9, 6}, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%v", tc.offset), func(t *testing.T) {
+			out, err := parser.Run(&Query{Mode: "comment", Offset: tc.offset})
+			if !errorContains(err, tc.wantErr) {
+				t.Fatalf("wrong error:\nwant: %v\ngot:  %v", tc.wantErr, err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			if !reflect.DeepEqual(out.Comment, tc.want) {
+				t.Fatalf("wrong output:\nwant: %v\ngot:  %v", tc.want, out.Comment)
+			}
+		})
+	}
+}
+
+// errorContains checks if the error message in out contains the text in
+// want.
+//
+// This is safe when out is nil. Use an empty string for want if you want to
+// test that err is nil.
+func errorContains(out error, want string) bool {
+	if out == nil {
+		return want == ""
+	}
+	if want == "" {
+		return false
+	}
+	return strings.Contains(out.Error(), want)
+}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func realMain() error {
 		flagDir    = flag.String("dir", "", "Directory to be parsed")
 		flagOffset = flag.Int("offset", 0, "Byte offset of the cursor position")
 		flagMode   = flag.String("mode", "",
-			"Running mode. One of {enclosing, next, prev, decls}")
+			"Running mode. One of {enclosing, next, prev, decls, comment}")
 		flagInclude = flag.String("include", "",
 			"Included declarations for mode {decls}. Comma delimited. Options: {func, type}")
 		flagShift         = flag.Int("shift", 0, "Shift value for the modes {next, prev}")
@@ -42,6 +42,10 @@ func realMain() error {
 
 	if *flagMode == "" {
 		return errors.New("no mode is passed")
+	}
+
+	if *flagMode == "comment" {
+		*flagParseComments = true
 	}
 
 	opts := &astcontext.ParserOptions{


### PR DESCRIPTION
This is useful to get the start/end information for a comment block, so
an "ac" ("a comment") textobj can be added to vim-go.