### PR TITLE
fix enclosing panic when parse function with no body

### DIFF
--- a/astcontext/funcs.go
+++ b/astcontext/funcs.go
@@ -242,6 +242,11 @@ func (f Funcs) EnclosingFunc(offset int) (*Func, error) {
 			start = fn.Doc.Offset
 		}
 
+		// function without body
+		if fn.Rbrace == nil {
+			continue
+		}
+
 		// one liner, start from the beginning to make it easier
 		if fn.FuncPos.Line == fn.Rbrace.Line {
 			start = fn.FuncPos.Offset - fn.FuncPos.Column


### PR DESCRIPTION
./main -file [/usr/local/go/src/net/http/server.go](https://github.com/golang/go/blob/master/src/net/http/server.go#L3219)  -offset 46379 -mode enclosing --format json